### PR TITLE
Fix favorites query key bug and type errors

### DIFF
--- a/client/src/components/property-card.tsx
+++ b/client/src/components/property-card.tsx
@@ -104,7 +104,7 @@ export default function PropertyCard({ property }: PropertyCardProps) {
           >
             <Heart
               className={`h-4 w-4 ${
-                isFavorited ? "fill-red-heart text-red-heart" : "text-gray-600"
+                isFavorited ? "fill-blue-heart text-blue-heart" : "text-gray-600"
               }`}
             />
           </Button>

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -40,7 +40,7 @@ export default function ProfilePage() {
         throw new Error("Failed to fetch profile");
       }
       const data: Profile = await response.json();
-      setRole(data.role);
+      setRole(data.role as "buyer" | "seller");
     } catch (error) {
       console.error("Error fetching profile:", error);
       toast({

--- a/client/src/pages/property-detail.tsx
+++ b/client/src/pages/property-detail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRoute, Link } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -36,6 +36,7 @@ export default function PropertyDetail() {
   const [, params] = useRoute("/property/:propertyId");
   const { toast } = useToast();
   const { user } = useAuth();
+  const queryClient = useQueryClient();
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [isContactDialogOpen, setIsContactDialogOpen] = useState(false);
   const [isFavorited, setIsFavorited] = useState(false);
@@ -53,7 +54,7 @@ export default function PropertyDetail() {
   });
 
   const { data: favorites, refetch: refetchFavorites } = useQuery<any[]>({
-    queryKey: [`userFavorites`, user?.id],
+    queryKey: ["favoriteProperties", user?.id],
     queryFn: async () => {
       if (!user?.id) return [];
       const response = await fetch(`/api/favorites/${user.id}`);
@@ -109,6 +110,9 @@ export default function PropertyDetail() {
             description: "This property has been removed from your favorites.",
           });
           refetchFavorites(); // Re-fetch favorites after removal
+          queryClient.invalidateQueries({
+            queryKey: ["favoriteProperties", user.id],
+          });
         } else {
           console.error("Failed to remove favorite:", await response.text());
           toast({
@@ -133,6 +137,9 @@ export default function PropertyDetail() {
             description: "This property has been added to your favorites.",
           });
           refetchFavorites(); // Re-fetch favorites after addition
+          queryClient.invalidateQueries({
+            queryKey: ["favoriteProperties", user.id],
+          });
         } else {
           console.error("Failed to add favorite:", await response.text());
           toast({
@@ -291,11 +298,11 @@ export default function PropertyDetail() {
                   className="absolute top-4 right-4 w-8 h-8 bg-white/80 hover:bg-white rounded-full"
                   onClick={toggleFavorite}
                 >
-                  <Heart
-                    className={`h-4 w-4 ${
-                      isFavorited ? "fill-red-heart text-red-heart" : "text-gray-600"
-                    }`}
-                  />
+                    <Heart
+                      className={`h-4 w-4 ${
+                        isFavorited ? "fill-blue-heart text-blue-heart" : "text-gray-600"
+                      }`}
+                    />
                 </Button>
 
                 <div className="absolute top-4 left-1/2 transform -translate-x-1/2 bg-white/90 text-dark-gray px-3 py-1 rounded-full text-sm font-medium">

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,10 +20,10 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as const,
   };
 
   const vite = await createViteServer({

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,7 @@ export default {
       },
       colors: {
         "red-heart": "#EF4444", // A vibrant red for the heart icon
+        "blue-heart": "#3B82F6", // A calm blue for the heart icon
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         card: {


### PR DESCRIPTION
## Summary
- standardize favorites query key across the app
- update PropertyDetail to invalidate favorite queries
- cast profile role type when loading
- fix Vite server options type
- use blue heart icon for favorites

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683f5f9cd8388321a24aedb445ab20be