### PR TITLE
Fix zip code search on listings page

### DIFF
--- a/client/src/pages/property-listings.tsx
+++ b/client/src/pages/property-listings.tsx
@@ -34,12 +34,7 @@ export default function PropertyListings() {
 
       if (q) {
         baseUrl = '/api/search';
-        // Check if 'q' is a 5-digit zip code
-        if (/^\d{5}$/.test(q)) {
-          currentParams.append('zipCode', q);
-        } else {
-          currentParams.append('q', q);
-        }
+        currentParams.append('q', q);
       }
 
       if (filters.priceMin) currentParams.append('priceMin', filters.priceMin.toString());


### PR DESCRIPTION
## Summary
- ensure the listings page always uses the `q` query parameter

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_683f9ec1a95083219405883cf5ef814e