### PR TITLE
Add ZIP code query filtering to property search

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -86,10 +86,15 @@ export async function registerRoutes(app: Express): Promise<void> {
   // Search properties by property ID or address
   app.get("/api/search", async (req, res) => {
     try {
-      const { q } = req.query;
+      const { q, zipCode } = req.query;
 
-      if (!q) {
+      if (!q && !zipCode) {
         return res.status(400).json({ message: "Search query is required" });
+      }
+
+      if (zipCode) {
+        const searchResults = await storage.searchProperties({ zipCode: zipCode as string });
+        return res.json(searchResults);
       }
 
       const query = q as string;


### PR DESCRIPTION
## Summary
- accept `zipCode` query param in `/api/search`
- if provided, filter properties by zip code using storage

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683faadee808832184a4afcf2c43bfe3